### PR TITLE
chore: update test workflow to modern macos versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-26, macos-26-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
This pull request updates the test matrix in the GitHub Actions workflow to include newer macOS versions and architectures. This ensures that the test suite is run on the latest available macOS runners, improving coverage and reliability for macOS users.

Platform support updates:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL11-R11): Updated the test matrix to replace `macos-13` with `macos-26` and added `macos-26-intel`, ensuring tests run on both ARM and Intel versions of the latest macOS.