### PR TITLE
Fix cog cask postflight xattr referencing wrong filename

### DIFF
--- a/Casks/cog.rb
+++ b/Casks/cog.rb
@@ -26,7 +26,8 @@ cask "cog" do
                        end}", target: "cog"
 
   postflight do
+    binary_name = "cog_Darwin_#{Hardware::CPU.arm? ? "arm64" : "x86_64"}"
     system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{staged_path}/cog"]
+                   args: ["-dr", "com.apple.quarantine", "#{staged_path}/#{binary_name}"]
   end
 end


### PR DESCRIPTION
## Summary

- Fixes `brew install --cask replicate/tap/cog` failing with `xattr: No such file` during postflight

## Problem

The `postflight` block runs `xattr -dr com.apple.quarantine` on `#{staged_path}/cog`, but the downloaded binary is named `cog_Darwin_arm64` (or `cog_Darwin_x86_64`) in the staged directory. The `binary` stanza creates a symlink with the target name `cog` in `/opt/homebrew/bin/`, but does **not** rename the file in the staged path.

```
xattr: No such file: /opt/homebrew/Caskroom/cog/0.17.1/cog
Error: Failure while executing; `/usr/bin/env /usr/bin/xattr -dr com.apple.quarantine /opt/homebrew/Caskroom/cog/0.17.1/cog` exited with 1.
```

## Fix

Use `Hardware::CPU.arm?` to construct the correct binary filename in the `postflight` block, matching the actual file in the staged directory.

## Validation Steps

1. Uninstall existing cog: `brew uninstall --cask cog`
2. Untap and re-tap with this branch:
   ```
   brew untap replicate/tap
   brew tap replicate/tap https://github.com/replicate/homebrew-tap --branch fix/cog-cask-postflight-xattr
   ```
3. Install: `brew install --cask replicate/tap/cog`
4. Verify install succeeded without errors
5. Verify binary works: `cog --version`